### PR TITLE
Fix failsafe issue in parse_code, tests #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /venv
+*.pyc
+.vscode
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt -r dev-requirements.txt
 
 # add a couple .md/.html files into test folders
 
-python -m unittests tests/test_format.py
+python -m unittest
 ```
 
 

--- a/c2c_markdown/__init__.py
+++ b/c2c_markdown/__init__.py
@@ -172,8 +172,6 @@ def parse_code(text):
         # indefinitely, and performance decreases over time
         parser.reset()
 
-        parser.convert(text)
-
         try:
             text = parser.convert(text)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -28,7 +28,7 @@ def fake_get_markdown_parser(*args, **kwargs):
 
 class TestFormat(unittest.TestCase):
     """
-    parse_code() function shouold never raise an exception. All sensitives
+    parse_code() function should never raise an exception. All sensitive
     functions (parsing and cleaning) are inside a try-catch block. This
     test-case verify that, if some extension raises an excpetion, the good
     default message (_PARSER_EXCEPTION_MESSAGE) is returned.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ class TestFormat(unittest.TestCase):
     """
     parse_code() function should never raise an exception. All sensitive
     functions (parsing and cleaning) are inside a try-catch block. This
-    test-case verify that, if some extension raises an excpetion, the good
+    test-case verifies that, if some extension raises an exception, the appropriate
     default message (_PARSER_EXCEPTION_MESSAGE) is returned.
     """
     def setUp(self):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,45 @@
+import unittest
+import markdown
+from markdown.extensions import Extension
+from markdown.blockprocessors import BlockProcessor
+
+import c2c_markdown
+
+
+class FailingProcessor(BlockProcessor):
+    def test(self, parent, block):
+        return True
+
+    def run(self, parent, blocks):
+        raise Exception("I should be invisible")
+
+
+class FailingExtension(Extension):
+    def extendMarkdown(self, md, md_globals):  # noqa
+        md.parser.blockprocessors.add('Failing', FailingProcessor(md.parser),
+                                      "<paragraph")
+
+
+def fake_get_markdown_parser(*args, **kwargs):
+    return markdown.Markdown(output_format='xhtml5',
+                             extensions=[FailingExtension()],
+                             enable_attributes=False)
+
+
+class TestFormat(unittest.TestCase):
+    """
+    parse_code() function shouold never raise an exception. All sensitives
+    functions (parsing and cleaning) are inside a try-catch block. This
+    test-case verify that, if some extension raises an excpetion, the good
+    default message (_PARSER_EXCEPTION_MESSAGE) is returned.
+    """
+    def setUp(self):
+        self.real_get_markdown_parser = c2c_markdown._get_markdown_parser
+        c2c_markdown._get_markdown_parser = fake_get_markdown_parser
+
+    def test_exception(self):
+        result = c2c_markdown.parse_code("!! Hello")
+        self.assertEqual(result, c2c_markdown._PARSER_EXCEPTION_MESSAGE)
+
+    def tearDown(self):
+        c2c_markdown._get_markdown_parser = self.real_get_markdown_parser


### PR DESCRIPTION
Parse_code() must never raise an exception. To achieve that, all suspect function are in a try-except block.

It was not the case here...